### PR TITLE
numerical instability fixed at around 2 Å in ErpenbeckThoss model

### DIFF
--- a/src/Friction_Evaluators.jl
+++ b/src/Friction_Evaluators.jl
@@ -65,8 +65,7 @@ function (friction_method::WideBandExact)(potential, ∂potentialᵢ, ∂potenti
 
     A(ϵ) = 1/π * Γ/2 / ((ϵ-h)^2 + (Γ/2)^2)
     kernel(ϵ) = -π * (∂hᵢ + (ϵ-h)*∂Γᵢ/Γ) * (∂hⱼ + (ϵ-h)*∂Γⱼ/Γ) * A(ϵ)^2 * ∂fermi(ϵ, μ, β)
-    diagonal = @view potential[diagind(potential)]
-    integral, _ = QuadGK.quadgk(kernel, extrema(diagonal)...)
+    integral, _ = QuadGK.quadgk(kernel, -Inf, Inf; rtol=1e-6)
     return integral
 end
 


### PR DESCRIPTION
## Fix friction integration bounds to remove artefact near singularity (~2 Å)

**Problem**

The existing integration in `Friction_Evaluators.jl` (line 69) uses `extrema(diagonal)` as the integration bounds:

```julia
integral, _ = QuadGK.quadgk(kernel, extrema(diagonal)...)
```
The result is a spurious small valley in the friction coefficient near the singularity at ~2 Å.

**Fix**

Replace with an improper integral over the full real line with a relative tolerance:

```julia
integral, _ = QuadGK.quadgk(kernel, -Inf, Inf; rtol=1e-6)
```

This matches the approach used in the analytical friction evaluator with an ensured numerical relative tolerance.

**Results**

The two methods now agree across all positions. The valley artefact near ~2 Å is eliminated.

| Before | After |
|--------|-------|
| Spurious valley visible at ~2 Å | Methods agree, artefact removed |
| ![Before](https://github.com/user-attachments/assets/b75c7cb6-f6af-4ed8-a453-98120007ea00) | ![After](https://github.com/user-attachments/assets/3c5bf0f8-5559-4fbe-85ad-7c6a4d246638) |


**NQCD Markovian friction setup**

```julia
using NQCModels
using NQCDynamics
using NQCCalculators
using Unitful, UnitfulAtomic

params_list = dict_list(Dict{String, Any}(
    "impuritymodel" => [:ErpenbeckThossAdsorbate],
    "centre" => [0],
    "position" => [collect(2.0:0.001:2.05)],
    "temperature" => [300],
    "Γ" => [0.06],
))

bandwidth = 400
bandwidth_au = austrip.(bandwidth*u"eV")
nstates = 1000

function NQCD_MarkovianFriction(params_dict::Dict{String, Any}; nstates, bandwidth)
    @unpack  position, impuritymodel, temperature = params_dict

    temperature_au = austrip.(temperature*u"K")
    position_au = austrip.(position*u"Å")

    if impuritymodel == :ErpenbeckThossAdsorbate
        Γ = params_dict["Γ"]
        adsorbate_m = NQCModels.ErpenbeckThoss(;Γ=austrip(Γ*u"eV"))
        model = WideBandBath(adsorbate_m; step=bandwidth/nstates, bandmin=-bandwidth/2, bandmax=bandwidth/2)
        atoms = Atoms(1u"u")
        sim = Simulation{DiabaticMDEF}(atoms, model, friction_method=NQCCalculators.WideBandExact(model.ρ, 1/temperature_au))

        MarkovianFriction = [only(NQCCalculators.evaluate_friction(sim.cache, hcat(x))) for x in position_au]
        return MarkovianFriction
    end
end
```

